### PR TITLE
PI-40: Add kubectl eqcp plugin to copy file from/to pod

### DIFF
--- a/kubectl-eqcp.sh
+++ b/kubectl-eqcp.sh
@@ -63,7 +63,7 @@ useDefaultNamespace () {
     if command_exists kubens; then
         useNamespace $(kubens -c);
     else
-        currentNamespace="$(kubectl config view --minify | grep namespace:)"
+        currentNamespace="$(kubectl config view --context $CONTEXT --minify | grep namespace:)"
         namespacePrefix="    namespace: "
         useNamespace "${currentNamespace//$namespacePrefix/}";
     fi

--- a/kubectl-eqshell.sh
+++ b/kubectl-eqshell.sh
@@ -72,7 +72,7 @@ useDefaultNamespace () {
     if command_exists kubens; then
         useNamespace $(kubens -c);
     else
-        currentNamespace="$(kubectl config view --minify | grep namespace:)"
+        currentNamespace="$(kubectl config view --context $CONTEXT --minify | grep namespace:)"
         namespacePrefix="    namespace: "
         useNamespace "${currentNamespace//$namespacePrefix/}";
     fi


### PR DESCRIPTION
## Setup
1. Créer un symlink au même endroit que ton exécutable kubectl (`which kubectl`)
Dans mon cas, c'est `ln -s /Users/tdaigle/kronos/projects/kubectl-plugins/kubectl-eqshell.sh /usr/local/bin/kubectl-eqshell`
2. la commande `kubectl plugin list` devrait te montrer que eqcp est disponible
3. Être connecté (`kubelogin`)
4. Utiliser le tool

Ce setup est temporaire, une prochaine tâche est de faire en sorte que les plugin kube soit installé durant le bootcamp

## Tests pour la PR

- [ ] Valider que la command eqcp fonctionne avec une source locale et un pod kube comme destination
- [ ] Valider que la command eqcp fonctionne avec un pod kube comme source et une destination locale
- [ ] Par défaut, le context actuel dans la config est utilisé mais valider que l'option -c fonctionne aussi
- [ ] Par défaut, le namespace actuel dans la config est utilisé mais valider que l'option -n fonctionne aussi