### PR TITLE
Add Context and Namespace lists to documentation

### DIFF
--- a/kubectl-eqcp.sh
+++ b/kubectl-eqcp.sh
@@ -20,6 +20,9 @@ OPTIONS
         -n <namespace> Use specific namespace
         -o <container> Use a specific container
 
+<context> must be in prod|ca-accp|dsf-prod|dsf-accp|ia-prod|ia-accp|us-prod|us-accp|unstable
+<namespace> must be in account-service|admail|antivirus|argo-events|auth-server|backup|calculatrices|cert-manager|chartmuseum|circleci-exporter|cpanel|cpanel2|datagateways|default|environment-chooser|equisoft-connect|equisoft-plan|equisoft-plan-express|flux-system|gatekeeper-system|gearmand|getmail|github-exporter|importpdftool|investor-profile|kube-node-lease|kube-public|kube-system|logdna|login|mediawiki|monitoring|pdf-api|premium-calculator|purecloud|rabbitmq|redirector|scan|voice|zpush
+
 EXAMPLES
         kubectl eqcp ~/path/to/local/file equisoft-plan-worker-7612a51-55a24:path/to/pod/file
         kubectl eqcp ca-accp:path/to/pod/file ~/path/to/local/file

--- a/kubectl-eqshell.sh
+++ b/kubectl-eqshell.sh
@@ -17,7 +17,10 @@ OPTIONS
         -n <namespace> Use specific namespace
         -o <container> Use specific container
         -i <index> Specifies pod to connect to by index
-        -l Lists running pod names for namespace." 1>&2;
+        -l Lists running pod names for namespace
+
+<context> must be in prod|ca-accp|dsf-prod|dsf-accp|ia-prod|ia-accp|us-prod|us-accp|unstable
+<namespace> must be in account-service|admail|antivirus|argo-events|auth-server|backup|calculatrices|cert-manager|chartmuseum|circleci-exporter|cpanel|cpanel2|datagateways|default|environment-chooser|equisoft-connect|equisoft-plan|equisoft-plan-express|flux-system|gatekeeper-system|gearmand|getmail|github-exporter|importpdftool|investor-profile|kube-node-lease|kube-public|kube-system|logdna|login|mediawiki|monitoring|pdf-api|premium-calculator|purecloud|rabbitmq|redirector|scan|voice|zpush" 1>&2;
     exit 1;
 }
 

--- a/kubectl-eqtool.sh
+++ b/kubectl-eqtool.sh
@@ -16,7 +16,10 @@ OPTIONS
         -p <pod> Use specific pod
         -c <context> Use specific context
         -n <namespace> Use specific namespace
-        -o <container> Specify a container." 1>&2;
+        -o <container> Specify a container
+
+<context> must be in prod|ca-accp|dsf-prod|dsf-accp|ia-prod|ia-accp|us-prod|us-accp|unstable
+<namespace> must be in account-service|admail|antivirus|argo-events|auth-server|backup|calculatrices|cert-manager|chartmuseum|circleci-exporter|cpanel|cpanel2|datagateways|default|environment-chooser|equisoft-connect|equisoft-plan|equisoft-plan-express|flux-system|gatekeeper-system|gearmand|getmail|github-exporter|importpdftool|investor-profile|kube-node-lease|kube-public|kube-system|logdna|login|mediawiki|monitoring|pdf-api|premium-calculator|purecloud|rabbitmq|redirector|scan|voice|zpush" 1>&2;
     exit 1;
 }
 


### PR DESCRIPTION
Pour les 3 outils actuels, j'ai ajouté de la documentations concernant les contextes et namespaces possibles.
Cependant, gardons en tête qu'il est possible que pour un utilisateur, cette nouvelle documentation peut ne pas être valide puisque:
1. Chaque contexte doit être ajouté manuellement par l'utilisateur (et donc, la création d'un nouveau contexte ex: dsf-prod) ne garanti pas chaque personne va l'avoir de disponible.
2. La liste des namespace est propre à chaque context, pour l'instant tous nos env sont des copié-collé, mais cela peut ne pas être toujours le cas.