### PR TITLE
QCTECH-322 fix(plugins): update handling of context prefix so we can use plugins with teleport.staging.equisoft.io

### DIFF
--- a/kubectl-eqshell.sh
+++ b/kubectl-eqshell.sh
@@ -57,6 +57,10 @@ listValidNamespaces () {
     echo $namespaces
 }
 
+listValidContainers () {
+    echo " $(kubectl --request-timeout=2 --context $CONTEXT get pods -n $NAMESPACE $POD -o jsonpath='{.spec.containers[*].name}') ";
+}
+
 listAllPods () {
     kubectl --request-timeout=2 --context $CONTEXT -n $NAMESPACE get pods  --field-selector=status.phase=Running -o=name | sed -e 's/pod\///' | grep -v "memcached" | grep -v "frontend" | grep -v "cron";
 }
@@ -152,7 +156,7 @@ useDefaultContainer () {
 }
 
 useContainer () {
-    validContainers=($(kubectl --request-timeout=2 --context $CONTEXT get pods -n $NAMESPACE $POD -o jsonpath='{.spec.containers[*].name}'));
+    validContainers=$(listValidContainers);
     if [[ "$validContainers" == *"$1"* ]]; then
         CONTAINER="$1"
     else
@@ -170,7 +174,7 @@ connect () {
     command="kubectl --request-timeout=2 --context $CONTEXT -n $NAMESPACE exec -it $POD";
     if [[ $CONTAINER ]]; then
         printf '\e[36m%b\e[0m\n' "Connecting in $PRETTY_CONTEXT environment on \"$NAMESPACE:$POD\" in its container \"$CONTAINER\"!";
-        command+=" -c $CONTAINER";
+        command="${command} -c $CONTAINER";
     else
         printf '\e[36m%b\e[0m\n' "Connecting in $PRETTY_CONTEXT environment on \"$NAMESPACE:$POD\" in its default container!";
     fi

--- a/kubectl-eqshell.sh
+++ b/kubectl-eqshell.sh
@@ -2,7 +2,8 @@
 
 set -e;
 
-readonly CTX_PREFIX="teleport.ca.equisoft.io-"
+readonly STAGING_CTX_PREFIX="teleport.staging.equisoft.io-"
+readonly PROD_CTX_PREFIX="teleport.ca.equisoft.io-"
 
 printUsage () {
     echo -e "
@@ -38,8 +39,12 @@ command_exists () {
 }
 
 listValidContexts () {
-    CTXs=" $(kubectl --request-timeout=2 config view -o jsonpath='{.contexts[*].name}') ";
-    echo "${CTXs//$CTX_PREFIX/}";
+    echo " $(kubectl --request-timeout=2 config view -o jsonpath='{.contexts[*].name}') ";
+}
+
+formatValidContexts () {
+    validContexts=$(listValidContexts);
+    echo "$validContexts" | sed -e "s/$STAGING_CTX_PREFIX/staging/g" | sed -e "s/$PROD_CTX_PREFIX//g";
 }
 
 listValidNamespaces () {
@@ -70,21 +75,28 @@ getCurrentContext() {
   else
       currentContext=$(kubectl config current-context)
   fi
-  echo $currentContext
+  echo "$currentContext"
 }
 
 useDefaultContext () {
     currentContext=$(getCurrentContext)
-    useContext "${currentContext//$CTX_PREFIX/}";
+    contextPrefix="$PROD_CTX_PREFIX"
+    if [[ "$currentContext" == *"$STAGING_CTX_PREFIX"* ]]; then
+      contextPrefix="$STAGING_CTX_PREFIX"
+    fi
+    useContext "${currentContext//$contextPrefix/}";
 }
 
 useContext () {
     validContexts=$(listValidContexts);
-    if [[ "$validContexts" == *" $1 "* ]]; then
-      PRETTY_CONTEXT="$1";
-      CONTEXT="$CTX_PREFIX$1";
+    PRETTY_CONTEXT="$1";
+    if [[ "staging" == "$PRETTY_CONTEXT" ]]; then
+      CONTEXT="$STAGING_CTX_PREFIX$PRETTY_CONTEXT";
+    elif [[ "$validContexts" == *" $PROD_CTX_PREFIX$PRETTY_CONTEXT "* ]]; then
+      CONTEXT="$PROD_CTX_PREFIX$PRETTY_CONTEXT";
     else
-      printf '\e[31m%b\e[0m\n' "Invalid context (environment): $1. Must be in $validContexts";
+      formattedValidContexts=$(formatValidContexts);
+      printf '\e[31m%b\e[0m\n' "Invalid context (environment): $1. Must be in $formattedValidContexts";
       exit 1;
     fi
 }
@@ -198,13 +210,13 @@ shift $((OPTIND-1));
 POD=$1
 
 if [[ $context ]]; then
-    useContext $context;
+    useContext "$context";
 else
     useDefaultContext;
 fi
 
 if [[ $namespace ]]; then
-    useNamespace $namespace;
+    useNamespace "$namespace";
 else
     useDefaultNamespace;
 fi
@@ -217,13 +229,13 @@ fi
 if [[ $POD ]]; then
     true;
 elif [[ $podIndex ]]; then
-    usePodByIndex $podIndex
+    usePodByIndex "$podIndex"
 else
     useDefaultPod
 fi
 
 if [[ $container ]]; then
-    useContainer $container;
+    useContainer "$container";
 else
     useDefaultContainer;
 fi

--- a/kubectl-eqtool.sh
+++ b/kubectl-eqtool.sh
@@ -2,7 +2,8 @@
 
 set -e;
 
-readonly CTX_PREFIX="teleport.ca.equisoft.io-"
+readonly STAGING_CTX_PREFIX="teleport.staging.equisoft.io-"
+readonly PROD_CTX_PREFIX="teleport.ca.equisoft.io-"
 
 printUsage () {
     echo -e "
@@ -27,9 +28,14 @@ command_exists () {
     type "$1" &> /dev/null;
 }
 
+
 listValidContexts () {
-    CTXs=" $(kubectl --request-timeout=2 config view -o jsonpath='{.contexts[*].name}') ";
-    echo "${CTXs//$CTX_PREFIX/}";
+    echo " $(kubectl --request-timeout=2 config view -o jsonpath='{.contexts[*].name}') ";
+}
+
+formatValidContexts () {
+    validContexts=$(listValidContexts);
+    echo "$validContexts" | sed -e "s/$STAGING_CTX_PREFIX/staging/g" | sed -e "s/$PROD_CTX_PREFIX//g";
 }
 
 listValidNamespaces () {
@@ -60,22 +66,29 @@ getCurrentContext() {
   else
       currentContext=$(kubectl config current-context)
   fi
-  echo $currentContext
+  echo "$currentContext"
 }
 
 useDefaultContext () {
     currentContext=$(getCurrentContext)
-    useContext "${currentContext//$CTX_PREFIX/}";
+    contextPrefix="$PROD_CTX_PREFIX"
+    if [[ "$currentContext" == *"$STAGING_CTX_PREFIX"* ]]; then
+      contextPrefix="$STAGING_CTX_PREFIX"
+    fi
+    useContext "${currentContext//$contextPrefix/}";
 }
 
 useContext () {
     validContexts=$(listValidContexts);
-    if [[ "$validContexts" == *" $1 "* ]]; then
-        PRETTY_CONTEXT="$1";
-        CONTEXT="$CTX_PREFIX$1";
+    PRETTY_CONTEXT="$1";
+    if [[ "staging" == "$PRETTY_CONTEXT" ]]; then
+      CONTEXT="$STAGING_CTX_PREFIX$PRETTY_CONTEXT";
+    elif [[ "$validContexts" == *" $PROD_CTX_PREFIX$PRETTY_CONTEXT "* ]]; then
+      CONTEXT="$PROD_CTX_PREFIX$PRETTY_CONTEXT";
     else
-        printf '\e[31m%b\e[0m\n' "Invalid context (environment): $1. Must be in $validContexts";
-        exit 1;
+      formattedValidContexts=$(formatValidContexts);
+      printf '\e[31m%b\e[0m\n' "Invalid context (environment): $1. Must be in $formattedValidContexts";
+      exit 1;
     fi
 }
 
@@ -169,13 +182,13 @@ done
 shift $((OPTIND-1));
 
 if [[ $context ]]; then
-    useContext $context;
+    useContext "$context";
 else
     useDefaultContext;
 fi
 
 if [[ $namespace ]]; then
-    useNamespace $namespace;
+    useNamespace "$namespace";
 else
     useDefaultNamespace;
 fi
@@ -187,7 +200,7 @@ else
 fi
 
 if [[ $container ]]; then
-    useContainer $container;
+    useContainer "$container";
 else
     useDefaultContainer;
 fi

--- a/kubectl-eqtool.sh
+++ b/kubectl-eqtool.sh
@@ -48,6 +48,10 @@ listValidNamespaces () {
     echo $namespaces
 }
 
+listValidContainers () {
+    echo " $(kubectl --request-timeout=2 --context $CONTEXT get pods -n $NAMESPACE $POD -o jsonpath='{.spec.containers[*].name}') ";
+}
+
 listValidPods () {
     kubectl --request-timeout=2 --context $CONTEXT -n $NAMESPACE get pods --field-selector=status.phase=Running -o=name | sed -e 's/pod\///' | grep -v "memcached" | grep -v "frontend" | grep -v "cron";
 }
@@ -135,7 +139,7 @@ useDefaultContainer () {
 }
 
 useContainer () {
-    validContainers=($(kubectl --request-timeout=2 --context $CONTEXT get pods -n $NAMESPACE $POD -o jsonpath='{.spec.containers[*].name}'));
+    validContainers=$(listValidContainers);
     if [[ "$validContainers" == *"$1"* ]]; then
         CONTAINER="$1"
     else
@@ -150,7 +154,7 @@ tool () {
     command="kubectl --request-timeout=2 --context $CONTEXT -n $NAMESPACE exec -it $POD"
     if [[ $CONTAINER ]]; then
         printf '\e[36m%b\e[0m\n' "Running tool in $PRETTY_CONTEXT environment on \"$NAMESPACE:$POD\" in its container \"$CONTAINER\""
-        command+=" -c $CONTAINER"
+        command="${command} -c $CONTAINER";
     else
         printf '\e[36m%b\e[0m\n' "Running tool in $PRETTY_CONTEXT environment on \"$NAMESPACE:$POD\" in its default container"
     fi


### PR DESCRIPTION
On souhaite pouvoir utiliser les plugins dans l'env de staging.

## Pour tester les plugins
1. Connecte toi au VPN et à teleport
2. Exécute les différents script ex: `./kubectl-eqtool.sh -n equisoft-connect -c staging`

### Tests spécifiques
- [x] Tester tous les plugins en Staging pour t'assurer que ça fonctionne
- [x] Tester sans spécifier de context pour qu'il utilise celui par défaut, ex `./kubectl-eqshell.sh` après avoir fait `kubectx teleport.staging.equisoft.io-staging`